### PR TITLE
fix: ensure 3d loading screen is visible

### DIFF
--- a/src/components/ui/loader.tsx
+++ b/src/components/ui/loader.tsx
@@ -232,14 +232,12 @@ export const Loader: FC<{ progress: number }> = ({ progress }) => {
   return (
     <div
       className="fixed top-0 left-0 w-full h-full z-[100]"
-      style={{ pointerEvents: 'none' }}
     >
       <Suspense fallback={<LoaderComponent />}>
         <Canvas
           shadows
           camera={{ position: [0, 0, 12], fov: 35 }}
           gl={{ preserveDrawingBuffer: true, antialias: true, powerPreference: 'high-performance' }}
-          style={{ pointerEvents: 'auto' }}
         >
           <Scene progress={progress} colors={colors} />
           <Preload all />


### PR DESCRIPTION
This commit fixes a rendering issue where the 3D loading screen was not appearing.

The root cause was a `pointer-events: 'none'` style on the loader's main container `div`. This CSS property was preventing the browser from rendering the component and its children, including the 3D canvas.

The fix removes the problematic style, allowing the loader to render correctly as intended.